### PR TITLE
Fix doxygen generation

### DIFF
--- a/doc/update-gh-pages.sh
+++ b/doc/update-gh-pages.sh
@@ -42,11 +42,10 @@ else
 fi
 
 echob "Build doxygen documentation."
-if ! doxygen "${script_path}"; then
+if ! ( cd $script_path && doxygen "Doxyfile" ); then
     echo "- Doxygen generation failed."
     exit 1
 fi
-mv "${project_path}/html/" "${script_path}"
 echo "- Check files"
 ls "${script_path}/html/"
 


### PR DESCRIPTION
The `update-gh-pages.sh` script is calling doxygen from the git repository root directory, so the `../src` makes Doxygen try to get src files from outside of the git repo. It is also not pointing to `docs/Doxyfile`


Fix #7 